### PR TITLE
Optimize blob validation.

### DIFF
--- a/src/main/java/com/emc/ecs/zimbra/integration/EcsLocatorUtil.java
+++ b/src/main/java/com/emc/ecs/zimbra/integration/EcsLocatorUtil.java
@@ -51,17 +51,13 @@ public class EcsLocatorUtil {
             throw new IllegalArgumentException("Invalid locator String");
     }
 
-    public static String getBucketNameBase() {
-        return String.format("%s.%s", ZIMBRA, getConfiguration().getZimbraStoreName());
-    }
-
     public static String getBucketName(Mailbox mbox) {
         switch (getConfiguration().getMailboxLocatorScheme()) {
         case Bucket:
-            return String.format("%s.%s", getBucketNameBase(), mbox.getId());
+            return String.format("%s.%s", ZIMBRA, mbox.getAccountId());
         case Prefix:
         default:
-            return getBucketNameBase();
+            return ZIMBRA;
         }
     }
 
@@ -84,7 +80,7 @@ public class EcsLocatorUtil {
             return "";
         case Prefix:
         default:
-            return String.format("%s.", mbox.getId());
+            return String.format("%s.", mbox.getAccountId());
         }
     }
 

--- a/src/main/java/com/emc/ecs/zimbra/integration/EcsMailboxBlob.java
+++ b/src/main/java/com/emc/ecs/zimbra/integration/EcsMailboxBlob.java
@@ -1,0 +1,37 @@
+package com.emc.ecs.zimbra.integration;
+
+import java.io.IOException;
+
+import com.zimbra.cs.mailbox.Mailbox;
+import com.zimbra.cs.store.StoreManager;
+import com.zimbra.cs.store.external.ExternalMailboxBlob;
+
+import com.emc.ecs.zimbra.integration.util.EcsLogger;
+
+/**
+ * <p>
+ * ExternalMailboxBlob implementation that supports validation
+ * </p>
+ */
+
+public class EcsMailboxBlob extends ExternalMailboxBlob {
+
+    protected EcsMailboxBlob(Mailbox mbox, int itemId, int revision, String locator) {
+        super(mbox, itemId, revision, locator);
+    }
+
+    @Override
+    public boolean validateBlob() {
+        EcsStoreManager sm = (EcsStoreManager) StoreManager.getInstance();
+        boolean status = false;
+
+        try {
+            status = sm.validateFromStore(getLocator(), getMailbox());
+        } catch (IOException e) {
+            EcsLogger.warn(String.format("Failed to validate - %s", getLocator()));
+        }
+
+        return status;
+    }
+
+}

--- a/src/main/java/com/emc/ecs/zimbra/integration/EcsStoreManager.java
+++ b/src/main/java/com/emc/ecs/zimbra/integration/EcsStoreManager.java
@@ -181,6 +181,33 @@ public class EcsStoreManager extends ExternalStoreManager {
 
     /**
      * <p>
+     * Verify an object exists in the store.
+     * </p>
+     *
+     * @param locator identifier string for the blob as returned from write operation
+     * @param mbox    Mailbox which contains the blob
+     * @return boolean indicating whether the object exists
+     * @throws IOException
+     */
+    public boolean validateFromStore(String locator, Mailbox mbox) throws IOException {
+        EcsLogger.debug(String.format("validateFromStore() - start: locator - %s, accountId - %s", locator, mbox.getAccountId()));
+
+        EcsLocator el = EcsLocatorUtil.fromStringLocator(locator);
+
+        S3ObjectMetadata metadata = null;
+
+        try {
+            metadata = client.getObjectMetadata(el.getBucketName(), el.getKey());
+        } catch (Exception e) {
+            EcsLogger.error(String.format("Failed to retrieve metadata from - %s", el.getKey()));
+            throw new IOException(e);
+        }
+
+        return (metadata == null) ? false : true;
+    }
+
+    /**
+     * <p>
      * Delete a blob from the store
      * </p>
      *

--- a/src/main/java/com/emc/ecs/zimbra/integration/EcsStoreManager.java
+++ b/src/main/java/com/emc/ecs/zimbra/integration/EcsStoreManager.java
@@ -126,7 +126,7 @@ public class EcsStoreManager extends ExternalStoreManager {
      */
     @Override
     public String writeStreamToStore(InputStream in, long actualSize, Mailbox mbox) throws IOException {
-        EcsLogger.debug(String.format("writeStreamToStore() - start: actualSize - %s, accountId - %s", actualSize, mbox.getId()));
+        EcsLogger.debug(String.format("writeStreamToStore() - start: actualSize - %s, accountId - %s", actualSize, mbox.getAccountId()));
 
         EcsLocator locator = EcsLocatorUtil.generateEcsLocator(mbox);
 
@@ -171,7 +171,7 @@ public class EcsStoreManager extends ExternalStoreManager {
      */
     @Override
     public InputStream readStreamFromStore(String locator, Mailbox mbox) throws IOException {
-        EcsLogger.debug(String.format("readStreamFromStore() - start: locator - %s, accountId - %s", locator, mbox.getId()));
+        EcsLogger.debug(String.format("readStreamFromStore() - start: locator - %s, accountId - %s", locator, mbox.getAccountId()));
 
         EcsLocator el = EcsLocatorUtil.fromStringLocator(locator);
 
@@ -191,7 +191,7 @@ public class EcsStoreManager extends ExternalStoreManager {
      */
     @Override
     public boolean deleteFromStore(final String locator, Mailbox mbox) throws IOException {
-        EcsLogger.debug(String.format("deleteFromStore() - start: locator - %s, accountId - %s", locator, mbox.getId()));
+        EcsLogger.debug(String.format("deleteFromStore() - start: locator - %s, accountId - %s", locator, mbox.getAccountId()));
 
         final EcsLocator el = EcsLocatorUtil.fromStringLocator(locator);
 


### PR DESCRIPTION
This overrides the ExternalMailboxBlob#validateBlob() with an implementation that retrieves only metadata instead of the full message.  In addition to reducing unnecessary traffic, it should increase the hit rate on the message cache.