### PR TITLE
Switch from mailbox id to account id.

### DIFF
--- a/src/main/java/com/emc/ecs/zimbra/integration/EcsLocatorUtil.java
+++ b/src/main/java/com/emc/ecs/zimbra/integration/EcsLocatorUtil.java
@@ -51,17 +51,13 @@ public class EcsLocatorUtil {
             throw new IllegalArgumentException("Invalid locator String");
     }
 
-    public static String getBucketNameBase() {
-        return String.format("%s.%s", ZIMBRA, getConfiguration().getZimbraStoreName());
-    }
-
     public static String getBucketName(Mailbox mbox) {
         switch (getConfiguration().getMailboxLocatorScheme()) {
         case Bucket:
-            return String.format("%s.%s", getBucketNameBase(), mbox.getId());
+            return String.format("%s.%s", ZIMBRA, mbox.getAccountId());
         case Prefix:
         default:
-            return getBucketNameBase();
+            return ZIMBRA;
         }
     }
 
@@ -84,7 +80,7 @@ public class EcsLocatorUtil {
             return "";
         case Prefix:
         default:
-            return String.format("%s.", mbox.getId());
+            return String.format("%s.", mbox.getAccountId());
         }
     }
 

--- a/src/main/java/com/emc/ecs/zimbra/integration/EcsStoreManager.java
+++ b/src/main/java/com/emc/ecs/zimbra/integration/EcsStoreManager.java
@@ -126,7 +126,7 @@ public class EcsStoreManager extends ExternalStoreManager {
      */
     @Override
     public String writeStreamToStore(InputStream in, long actualSize, Mailbox mbox) throws IOException {
-        EcsLogger.debug(String.format("writeStreamToStore() - start: actualSize - %s, accountId - %s", actualSize, mbox.getId()));
+        EcsLogger.debug(String.format("writeStreamToStore() - start: actualSize - %s, accountId - %s", actualSize, mbox.getAccountId()));
 
         EcsLocator locator = EcsLocatorUtil.generateEcsLocator(mbox);
 
@@ -171,7 +171,7 @@ public class EcsStoreManager extends ExternalStoreManager {
      */
     @Override
     public InputStream readStreamFromStore(String locator, Mailbox mbox) throws IOException {
-        EcsLogger.debug(String.format("readStreamFromStore() - start: locator - %s, accountId - %s", locator, mbox.getId()));
+        EcsLogger.debug(String.format("readStreamFromStore() - start: locator - %s, accountId - %s", locator, mbox.getAccountId()));
 
         EcsLocator el = EcsLocatorUtil.fromStringLocator(locator);
 
@@ -191,7 +191,7 @@ public class EcsStoreManager extends ExternalStoreManager {
      */
     @Override
     public boolean deleteFromStore(final String locator, Mailbox mbox) throws IOException {
-        EcsLogger.debug(String.format("deleteFromStore() - start: locator - %s, accountId - %s", locator, mbox.getId()));
+        EcsLogger.debug(String.format("deleteFromStore() - start: locator - %s, accountId - %s", locator, mbox.getAccountId()));
 
         final EcsLocator el = EcsLocatorUtil.fromStringLocator(locator);
 


### PR DESCRIPTION
This moves from using mailbox id to using account id, which is a system wide and persistent identifier for an account (and by extension) mailbox.

This allows us to eliminate EcsLocatorUtil#getBucketNameBase because account ids are globally unique, and ensures that EcsStoreManager#getAllBlobPaths will always return all blob paths associated with the account.  Currently it will only show all blob paths that were generated while the account was on the current server.